### PR TITLE
Fix duplicate game launch

### DIFF
--- a/src/assets/js/panels/home.js
+++ b/src/assets/js/panels/home.js
@@ -15,7 +15,7 @@ class Home {
         this.db = new database();
         this.news()
         this.socialLick()
-        this.instancesSelect()
+        // Defer instance selection setup until accounts are refreshed
         document.querySelector('.settings-btn').addEventListener('click', e => changePanel('settings'))
     }
 


### PR DESCRIPTION
## Summary
- prevent `startGame` from triggering twice by avoiding a duplicate call to `instancesSelect`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853ff4a0e108332a35194dbed2cbdae